### PR TITLE
Upgrade to mysql 8 for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
    db:
-     image: mysql:5.7
+     image: mysql:8
      volumes:
        - db_data:/var/lib/mysql
      environment:


### PR DESCRIPTION
Upgrade to mysql 8 for local development. This is so that we can support ARM running locally on Apple Silicon, as mysql images only from version 8+ support ARM (https://stackoverflow.com/questions/54470921/is-there-a-mysql-docker-image-for-arm64-that-works-like-the-official-image).

Note that I think we're still using mysql 5 in wpengine (though need to check).